### PR TITLE
fix: keep card replies in the same Lark topic/thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to **lark-opencode-bridge** are documented here.
 This project follows [Semantic Versioning](https://semver.org/).
 
+## [0.1.13] - 2026-07-20
+
+### Fixed
+- **Topic/thread replies** — card mode no longer posts a brand-new top-level
+  message (which becomes a new topic in topic-mode groups like Atlas Agent
+  Desk). Agent cards and markdown replies now use `messages-reply` against the
+  triggering message, with `--reply-in-thread` for group/topic context so
+  `@Tommy` stays in the same thread the user mentioned from. If the chat
+  rejects thread replies (`230071`), the bridge retries as a plain reply.
+
 ## [0.1.12] - 2026-06-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lark-opencode-bridge",
-  "version": "0.0.1",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lark-opencode-bridge",
-      "version": "0.0.1",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.65.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lark-opencode-bridge",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Feishu/Lark bot for local opencode — QR setup, streaming cards, /spawn groups, doc comments & attachments",
   "type": "module",
   "repository": {

--- a/src/core/bridge.ts
+++ b/src/core/bridge.ts
@@ -20,6 +20,7 @@ import { LarkSender } from "../lark/sender.js";
 import { LarkChats } from "../lark/chats.js";
 import { LarkAttachmentFetcher, type AttachmentRef } from "../lark/attach.js";
 import { CommentFetcher, type CommentReply, type CommentThread } from "../lark/comments.js";
+import { shouldReplyInThread } from "../lark/thread-reply.js";
 import {
   loadActiveLarkCredentials,
   fetchBotOpenId,
@@ -244,7 +245,7 @@ export class Bridge {
     log.info(
       `inbound msg chat=${evt.chat_id} type=${evt.chat_type} sender=${evt.sender_id} ` +
         `mentions=${evt.mentions.length} spawned=${this.sessions.isSpawned(evt.chat_id)} ` +
-        `reply_to=${evt.reply_to_message_id ?? "-"}`,
+        `reply_to=${evt.reply_to_message_id ?? "-"} thread=${evt.thread_id ?? "-"}`,
     );
 
     // Never process our own outbound messages — the welcome card sent during
@@ -601,7 +602,7 @@ export class Bridge {
     const opts = configFormOptsFromBridge(this.opts.config);
     const card = configFormCard(opts);
     try {
-      await this.sender.sendCard(evt.chat_id, card);
+      await this.sender.replyCard(evt.message_id, card, shouldReplyInThread(evt));
     } catch (err) {
       await this.replyMarkdown(evt, `无法发送配置卡片：${(err as Error).message}`);
     }
@@ -1353,7 +1354,14 @@ export class Bridge {
 
     let messageId: string | null = null;
     try {
-      messageId = await this.sender.sendCard(evt.chat_id, renderCard(state, meta));
+      // Always reply to the triggering message. In topic-mode groups, sendCard
+      // creates a brand-new top-level topic; reply-in-thread keeps the run in
+      // the same topic the user @mentioned from.
+      messageId = await this.sender.replyCard(
+        evt.message_id,
+        renderCard(state, meta),
+        shouldReplyInThread(evt),
+      );
     } catch (err) {
       log.warn(`card send failed, falling back to reply mode: ${(err as Error).message}`);
       await this.runWithReply(evt, sessionId, parts, rt);
@@ -1465,7 +1473,11 @@ export class Bridge {
 
   private async replyMarkdown(evt: LarkMessageEvent, body: string): Promise<void> {
     try {
-      await this.sender.reply({ messageId: evt.message_id, markdown: body });
+      await this.sender.reply({
+        messageId: evt.message_id,
+        markdown: body,
+        replyInThread: shouldReplyInThread(evt),
+      });
     } catch (err) {
       log.error(`reply failed: ${(err as Error).message}`);
     }

--- a/src/lark/sender.ts
+++ b/src/lark/sender.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { createLogger } from "../log.js";
+import { isThreadUnsupportedError } from "./thread-reply.js";
 
 const log = createLogger("lark.send");
 
@@ -31,7 +32,7 @@ export interface PatchCardOptions {
 export class LarkSender {
   constructor(private readonly opts: SenderOptions) {}
 
-  reply(o: ReplyOptions): Promise<void> {
+  async reply(o: ReplyOptions): Promise<void> {
     const args = [
       "im",
       "+messages-reply",
@@ -45,10 +46,20 @@ export class LarkSender {
     } else if (o.text) {
       args.push("--text", o.text);
     } else {
-      return Promise.reject(new Error("reply requires markdown or text"));
+      throw new Error("reply requires markdown or text");
     }
     if (o.replyInThread) args.push("--reply-in-thread");
-    return this.runVoid(args);
+    try {
+      await this.runVoid(args);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      if (o.replyInThread && isThreadUnsupportedError(detail)) {
+        log.warn("reply-in-thread unsupported (230071); retrying as plain reply");
+        await this.reply({ ...o, replyInThread: false });
+        return;
+      }
+      throw err;
+    }
   }
 
   send(o: SendOptions): Promise<void> {
@@ -81,14 +92,37 @@ export class LarkSender {
       this.opts.identity,
     ];
     const stdout = await this.run(args);
+    return this.parseMessageId(stdout);
+  }
+
+  /**
+   * Reply with an interactive card under an existing message. Prefer this over
+   * `sendCard` in topic-mode groups so the bot stays in the same topic/thread.
+   */
+  async replyCard(messageId: string, card: unknown, replyInThread = false): Promise<string> {
+    const args = [
+      "im",
+      "+messages-reply",
+      "--message-id",
+      messageId,
+      "--msg-type",
+      "interactive",
+      "--content",
+      JSON.stringify(card),
+      "--as",
+      this.opts.identity,
+    ];
+    if (replyInThread) args.push("--reply-in-thread");
     try {
-      const parsed = JSON.parse(stdout);
-      const messageId: string | undefined =
-        parsed?.data?.message_id ?? parsed?.message_id ?? parsed?.data?.message?.message_id;
-      if (!messageId) throw new Error(`no message_id in lark-cli response: ${stdout.slice(0, 400)}`);
-      return messageId;
+      const stdout = await this.run(args);
+      return this.parseMessageId(stdout);
     } catch (err) {
-      throw new Error(`failed to parse lark-cli response: ${(err as Error).message}`);
+      const detail = err instanceof Error ? err.message : String(err);
+      if (replyInThread && isThreadUnsupportedError(detail)) {
+        log.warn("reply-in-thread unsupported (230071); retrying card as plain reply");
+        return this.replyCard(messageId, card, false);
+      }
+      throw err;
     }
   }
 
@@ -107,6 +141,18 @@ export class LarkSender {
       this.opts.identity,
     ];
     return this.runVoid(args);
+  }
+
+  private parseMessageId(stdout: string): string {
+    try {
+      const parsed = JSON.parse(stdout);
+      const messageId: string | undefined =
+        parsed?.data?.message_id ?? parsed?.message_id ?? parsed?.data?.message?.message_id;
+      if (!messageId) throw new Error(`no message_id in lark-cli response: ${stdout.slice(0, 400)}`);
+      return messageId;
+    } catch (err) {
+      throw new Error(`failed to parse lark-cli response: ${(err as Error).message}`);
+    }
   }
 
   private runVoid(args: string[]): Promise<void> {

--- a/src/lark/thread-reply.ts
+++ b/src/lark/thread-reply.ts
@@ -1,0 +1,20 @@
+import type { LarkMessageEvent } from "./types.js";
+
+/**
+ * Whether outbound replies should use Lark `--reply-in-thread`.
+ *
+ * Topic-mode groups (e.g. Atlas Agent Desk) treat plain `messages-send` as a
+ * brand-new top-level topic. Prefer thread replies whenever the inbound
+ * message is already in a group/topic context.
+ */
+export function shouldReplyInThread(evt: Pick<LarkMessageEvent, "chat_type" | "thread_id" | "reply_to_message_id">): boolean {
+  return (
+    evt.chat_type !== "p2p" ||
+    Boolean(evt.thread_id) ||
+    Boolean(evt.reply_to_message_id)
+  );
+}
+
+export function isThreadUnsupportedError(detail: string): boolean {
+  return detail.includes("230071");
+}

--- a/src/lark/types.ts
+++ b/src/lark/types.ts
@@ -25,6 +25,8 @@ export interface LarkMessageEvent {
   mentions: MentionInfo[];
   /** When the user replies to or quotes another message, Feishu sets parent_id. */
   reply_to_message_id?: string;
+  /** Topic/thread id when the message already lives inside a topic (topic-mode groups). */
+  thread_id?: string;
 }
 
 export interface LarkCommentEvent {

--- a/src/lark/ws-consumer.ts
+++ b/src/lark/ws-consumer.ts
@@ -194,6 +194,7 @@ function adaptMessage(msg: NormalizedMessage): LarkMessageEvent | null {
     create_time: String(msg.createTime),
     mentions,
     reply_to_message_id: resolveReplyToMessageId(msg),
+    thread_id: resolveThreadId(msg),
   };
 }
 
@@ -202,6 +203,13 @@ function resolveReplyToMessageId(msg: NormalizedMessage): string | undefined {
   const raw = msg.raw as { message?: { parent_id?: string } } | undefined;
   const parent = raw?.message?.parent_id;
   return parent && parent !== "0" ? parent : undefined;
+}
+
+function resolveThreadId(msg: NormalizedMessage): string | undefined {
+  if (msg.threadId) return msg.threadId;
+  const raw = msg.raw as { message?: { thread_id?: string } } | undefined;
+  const threadId = raw?.message?.thread_id;
+  return threadId && threadId !== "0" ? threadId : undefined;
 }
 
 function adaptComment(evt: CommentEvent): LarkCommentEvent | null {

--- a/test/thread-reply.test.ts
+++ b/test/thread-reply.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isThreadUnsupportedError, shouldReplyInThread } from "../src/lark/thread-reply.js";
+
+describe("shouldReplyInThread", () => {
+  it("is true for group messages (topic desks treat send as new topic)", () => {
+    assert.equal(shouldReplyInThread({ chat_type: "group" }), true);
+  });
+
+  it("is true for group replies even without thread_id", () => {
+    assert.equal(
+      shouldReplyInThread({
+        chat_type: "group",
+        reply_to_message_id: "om_parent",
+      }),
+      true,
+    );
+  });
+
+  it("is true for p2p when thread_id or reply_to is present", () => {
+    assert.equal(
+      shouldReplyInThread({ chat_type: "p2p", thread_id: "omt_x" }),
+      true,
+    );
+    assert.equal(
+      shouldReplyInThread({ chat_type: "p2p", reply_to_message_id: "om_x" }),
+      true,
+    );
+  });
+
+  it("is false for bare p2p messages", () => {
+    assert.equal(shouldReplyInThread({ chat_type: "p2p" }), false);
+  });
+});
+
+describe("isThreadUnsupportedError", () => {
+  it("detects Lark 230071", () => {
+    assert.equal(isThreadUnsupportedError("lark-cli failed: code=230071"), true);
+    assert.equal(isThreadUnsupportedError("other error"), false);
+  });
+});


### PR DESCRIPTION
## Summary
In topic-mode groups (e.g. Atlas Agent Desk), card mode called `im +messages-send`, which creates a **new top-level topic** instead of replying in the thread where the bot was `@mentioned`.

## Fix
- Prefer `im +messages-reply` with `--reply-in-thread` for group/topic context (and when `thread_id` / `reply_to` is present).
- Capture inbound `thread_id` from the WS event when available.
- If Lark returns `230071` (thread replies unsupported), retry as a plain reply.
- Add unit coverage for the thread-reply decision helper.

## Test plan
- [x] `npm test` (typecheck + unit tests)
- [ ] In a topic-mode group: reply inside an existing topic with `@bot` and confirm the thinking card stays in that topic
- [ ] In p2p: confirm card/reply behavior unchanged